### PR TITLE
Update parameters.ts

### DIFF
--- a/src/lib/schwoerer/parameters.ts
+++ b/src/lib/schwoerer/parameters.ts
@@ -415,7 +415,7 @@ export const SchwoererParameter: { [index: string]: any } =
     {
         descr: "T6 im WT",
         category: "advanced",
-        modbus_r: 204,
+        modbus_r: 205,
         modbus_w: -1,
         value_type: "range",
         value_def: {


### PR DESCRIPTION
According to the Modbus TCP list of Schwörer, the Modbus address has to be 205 (and not 204) for T6 in WT:
https://schwoerer-service.com/storage/files/Community/2020/Parameterliste_Modbus_TCP_032020.pdf

Extract of "ioBroker.schwoerer-ventcube/src/lib/schwoerer/parameters.ts":
"t6-in-wt": { descr: "T6 im WT", category: "advanced", modbus_r: 204, modbus_w: -1, value_type: "range", value_def: { min: -50, max: 100, unit: "°C" }

It would be very nice to get that fixed.
Thank you very much in advance!
